### PR TITLE
Fix meta tag delimiters

### DIFF
--- a/templates/_header.inc.php
+++ b/templates/_header.inc.php
@@ -1,1 +1,1 @@
-<meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=0;"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0"/>


### PR DESCRIPTION
Google chrome complains about the semicolons in the meta viewport.

As far as I can tell, apple are the authoritative source for documentation on this and their docs explicitly recommend avoiding semicolon in favour of comma:

https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html